### PR TITLE
extended encode_logstash to allow empty sections

### DIFF
--- a/filter_plugins/config_encoders.py
+++ b/filter_plugins/config_encoders.py
@@ -530,6 +530,7 @@ def encode_logstash(
                             _is_num(val) or
                             isinstance(val, bool) or (
                                 isinstance(val, dict) and
+                                val and
                                 val.keys()[0][0] != section_prefix)):
                         rv += "\n%s}\n" % (indent * level)
                     else:


### PR DESCRIPTION
added support for following structures:
```
my_logstash_config:
  - :output:
      :stdout: {}
```
becomes
```
output {
  stdout {
  }
}
```