### PR TITLE
    Fix to address the issue described here:

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -737,48 +737,10 @@ The filter can have the following parameters:
 
 - ``backslash_escaping_ignore_string='@@@'``
   This parameter sets a string of characters than can be prepended
-  to a string used in the Logstash configuration specification to prevent
-  backslahes from being escaped in the resulting Logstash pipeline configuration
-  file.
+  to a string to prevent backslahes from being escaped in the resulting
+  Logstash pipeline configuration file::
 
-  For example, the following pipeline configuration::
-
-      - :grok:
-            match:
-              message: 'sshd(?:\[%{POSINT:[system][auth][pid]}\])?:'
-            add_tag: "i_%{instance_num}"
-            break_on_match: 'false'
-
-
-  Outputs::
-
-        grok {
-          add_tag => "i_%{instance_num}"
-          break_on_match => "false"
-          match => {
-            "message" =>  "sshd(?:\\[%{POSINT:[system][auth][pid]}\\])?:"
-          }
-        }
-
-  Notice the escaped backslashes in the output.
-
-  However, the following pipeline configuration, which uses the backslash_escaping_ignore_string::
-
-       - :grok:
-            match:
-              message: '@@@sshd(?:\[%{POSINT:[system][auth][pid]}\])?:'
-            add_tag: "i_%{instance_num}"
-        break_on_match: 'false'
-
-  Outputs::
-
-        grok {
-          add_tag => "i_%{instance_num}"
-          break_on_match => "false"
-          match => {
-            "message" =>  "sshd(?:\[%{POSINT:[system][auth][pid]}\])?:"
-          }
-        }
+    (e.g. `'@@@sshd(?:\[%{POSINT:[system][auth][pid]}\])?:'` will turn to `"sshd(?:\[%{POSINT:[system][auth][pid]}\])?:"` instead of to `"sshd(?:\\[%{POSINT:[system][auth][pid]}\\])?:"`).
 
 
 .. _encode-nginx:

--- a/README.rst
+++ b/README.rst
@@ -735,6 +735,51 @@ The filter can have the following parameters:
   This parameter specifies which character will be used to identify the
   Logstash section.
 
+- ``backslash_escaping_ignore_string='@@@'``
+  This parameter sets a string of characters than can be prepended
+  to a string used in the Logstash configuration specification to prevent
+  backslahes from being escaped in the resulting Logstash pipeline configuration
+  file.
+
+  For example, the following pipeline configuration::
+
+      - :grok:
+            match:
+              message: 'sshd(?:\[%{POSINT:[system][auth][pid]}\])?:'
+            add_tag: "i_%{instance_num}"
+            break_on_match: 'false'
+
+
+  Outputs::
+
+        grok {
+          add_tag => "i_%{instance_num}"
+          break_on_match => "false"
+          match => {
+            "message" =>  "sshd(?:\\[%{POSINT:[system][auth][pid]}\\])?:"
+          }
+        }
+
+  Notice the escaped backslashes in the output.
+
+  However, the following pipeline configuration, which uses the backslash_escaping_ignore_string::
+
+       - :grok:
+            match:
+              message: '@@@sshd(?:\[%{POSINT:[system][auth][pid]}\])?:'
+            add_tag: "i_%{instance_num}"
+        break_on_match: 'false'
+
+   Outputs::
+
+        grok {
+          add_tag => "i_%{instance_num}"
+          break_on_match => "false"
+          match => {
+            "message" =>  "sshd(?:\[%{POSINT:[system][auth][pid]}\])?:"
+          }
+        }
+
 
 .. _encode-nginx:
 
@@ -742,7 +787,7 @@ encode_nginx
 ^^^^^^^^^^^^
 
 This filter helps to create configuration in the format used by Nginx
-wweb server. The expected data structure is the following::
+web server. The expected data structure is the following::
 
     my_nginx_vhost_config:
       - server:

--- a/README.rst
+++ b/README.rst
@@ -736,11 +736,12 @@ The filter can have the following parameters:
   Logstash section.
 
 - ``backslash_escaping_ignore_string='@@@'``
-  This parameter sets a string of characters than can be prepended
-  to a string to prevent backslahes from being escaped in the resulting
-  Logstash pipeline configuration file::
 
-    (e.g. `'@@@sshd(?:\[%{POSINT:[system][auth][pid]}\])?:'` will turn to `"sshd(?:\[%{POSINT:[system][auth][pid]}\])?:"` instead of to `"sshd(?:\\[%{POSINT:[system][auth][pid]}\\])?:"`).
+  This parameter defines a sets of characters than can be prepended to a string
+  to prevent backslahes from being escaped in the resulting configuration (e.g.
+  ``"@@@sshd(?:\[%{POSINT:[system][auth][pid]}\])?:"`` will turn to
+  ``"sshd(?:\[%{POSINT:[system][auth][pid]}\])?:"`` instead of to
+  ``"sshd(?:\\[%{POSINT:[system][auth][pid]}\\])?:"``).
 
 
 .. _encode-nginx:

--- a/README.rst
+++ b/README.rst
@@ -770,7 +770,7 @@ The filter can have the following parameters:
             add_tag: "i_%{instance_num}"
         break_on_match: 'false'
 
-   Outputs::
+  Outputs::
 
         grok {
           add_tag => "i_%{instance_num}"

--- a/filter_plugins/config_encoders.py
+++ b/filter_plugins/config_encoders.py
@@ -92,11 +92,7 @@ def _escape(data, quote='"', format=None):
             replace('\r', '\\r').
             replace('\t', '\\t'))
     elif quote is not None and len(quote):
-        """Do not escape strings starting with @@@"""
-        if str(data).startswith('@@@'):
-            return re.sub('^@@@', '', str(data))
-        else:
-            return str(data).replace('\\', '\\\\').replace(quote, "\\%s" % quote)
+        return str(data).replace('\\', '\\\\').replace(quote, "\\%s" % quote)
     else:
         return data
 
@@ -524,7 +520,7 @@ def encode_json(
 
 def encode_logstash(
         data, convert_bools=False, convert_nums=False, indent="  ", level=0,
-        prevtype="", section_prefix=":"):
+        prevtype="", section_prefix=":", backslash_escaping_ignore_string='@@@'):
     """Convert Python data structure to Logstash format."""
 
     # Return value
@@ -603,7 +599,10 @@ def encode_logstash(
     elif isinstance(data, basestring):
         # It's a string
 
-        rv += '"%s"' % _escape(data)
+        if data.startswith(backslash_escaping_ignore_string):
+            rv += "%s" % data[len(backslash_escaping_ignore_string):]
+        else:
+            rv += '"%s"' % _escape(data)
 
     else:
         # It's a list

--- a/filter_plugins/config_encoders.py
+++ b/filter_plugins/config_encoders.py
@@ -92,7 +92,11 @@ def _escape(data, quote='"', format=None):
             replace('\r', '\\r').
             replace('\t', '\\t'))
     elif quote is not None and len(quote):
-        return str(data).replace('\\', '\\\\').replace(quote, "\\%s" % quote)
+        """Do not escape strings starting with @@@"""
+        if str(data).startswith('@@@'):
+            return re.sub('^@@@', '', str(data))
+        else:
+            return str(data).replace('\\', '\\\\').replace(quote, "\\%s" % quote)
     else:
         return data
 


### PR DESCRIPTION
    https://github.com/jtyr/ansible-config_encoder_filters/issues/4

    This is a modification to the _escape method where strings that
begin
    with '@@@' are not escaped and passed as is.