### PR TITLE
removing whitespace when 'param' is not present.

### DIFF
--- a/filter_plugins/config_encoders.py
+++ b/filter_plugins/config_encoders.py
@@ -147,6 +147,8 @@ def encode_apache(
                                 quote_all_nums=quote_all_nums,
                                 quote_all_strings=quote_all_strings,
                                 block_type='value')
+                        else:
+                            rv = rv.rstrip()
 
                         rv += ">\n"
                         rv += encode_apache(

--- a/filter_plugins/config_encoders.py
+++ b/filter_plugins/config_encoders.py
@@ -132,12 +132,13 @@ def encode_apache(
                             is_empty = True
 
                     if is_empty:
-                        rv += "%s<%s " % (indent * level, s['name'])
+                        rv += "%s<%s" % (indent * level, s['name'])
 
                         if 'operator' in s:
-                            rv += "%s " % s['operator']
+                            rv += " %s" % s['operator']
 
                         if 'param' in s:
+                            rv += ' '
                             rv += encode_apache(
                                 s['param'],
                                 convert_bools=convert_bools,
@@ -147,8 +148,6 @@ def encode_apache(
                                 quote_all_nums=quote_all_nums,
                                 quote_all_strings=quote_all_strings,
                                 block_type='value')
-                        else:
-                            rv = rv.rstrip()
 
                         rv += ">\n"
                         rv += encode_apache(


### PR DESCRIPTION
Here's the PR for the changes to the Apache config encoder to make it compatible with Fluentd.

Didn't think this change warrants any documentation updates.  Let me know if you disagree. 