### PR TITLE
Ensure list is not empty before checking its first entry in toml encoder

### DIFF
--- a/filter_plugins/config_encoders.py
+++ b/filter_plugins/config_encoders.py
@@ -800,7 +800,7 @@ def encode_toml(
 
                 first = False
                 tn = ''
-            elif isinstance(v, list) and not isinstance(v[0], dict):
+            elif isinstance(v, list) and (not v or not isinstance(v[0], dict)):
                 if tn:
                     if not first:
                         rv += "\n"
@@ -857,7 +857,7 @@ def encode_toml(
                     table_type='table')
 
                 first = False
-            elif isinstance(v, list) and isinstance(v[0], dict):
+            elif isinstance(v, list) and (not v or isinstance(v[0], dict)):
                 # Array of tables
                 tk = k
 


### PR DESCRIPTION
Given a sructure like:
```
foo: []
```
the toml encoder failed with an `IndexError: list index out of range` error, due to access tries on first element of an empty list